### PR TITLE
Use UD public domain profile links

### DIFF
--- a/src/lib/Feed.svelte
+++ b/src/lib/Feed.svelte
@@ -10,7 +10,7 @@
   let transactionExplorerUrl = explorerUrl + "/tx/" + feed.transactionHash;
   let addressExporerUrl = explorerUrl + "/address/" + feed.owner;
   let unstoppableDomainUrl =
-    "https://unstoppabledomains.com/search?searchTerm=" + encodeURIComponent(feed.uri);
+    "https://ud.me/" + encodeURIComponent(feed.uri);
   let shortAddr = (addr: string) => addr.substring(0, 6) + "..." + addr.substring(addr.length - 4);
   let randomElementId = "feed-" + Math.random().toString(36).substring(2);
   let feedElement: HTMLAnchorElement;


### PR DESCRIPTION
Unstoppable Domains support domain profiles where the domain owner can fill in more data/links about their domain.

If the domain profile does not exist the user will be redirected to search (same URL as currently being used).

Just a small tweak.
Thanks for contribution!